### PR TITLE
Adds CockroachDB integration tests

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,3 +1,9 @@
+coverage:
+  precision: 0 # the percentage seems to be vary by ~0.3%
+  status:
+    project:
+      default:
+        informational: true # don't block PRs until we fix all flakes
 comment:
   layout: "diff, flags, files"
   behavior: default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,17 +59,13 @@ jobs:
           fail_ci_if_error: true
           verbose: false
 
-  it:
+  it-postgres:
     if: "!contains(github.event.commits[0].message, '[skip ci]')"
     needs: fmt
     strategy:
       matrix:
-        backend: ["postgres", "cockroachdb"]
-        include:
-          - backend: "postgres"
-            tag: [13, 12, 11, 10, 9]
-          - backend: "cockroachdb"
-            tag: ["v20.2.0"]
+        backend: ["postgres"]
+        tag: [13, 12, 11, 10, 9]
 
     runs-on: ubuntu-latest
 
@@ -91,6 +87,41 @@ jobs:
           TEST_BACKEND: ${{matrix.backend}}
           TEST_BACKEND_TAG: ${{matrix.tag}}
         run: CI_UID_GID="$(id -u):$(id -g)" sbt -J-Xmx2G coverage it:test coverageReport
+      - uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: integration-${{matrix.backend}}-${{matrix.tag}}
+          fail_ci_if_error: true
+          verbose: false
+
+  it-crdb:
+    if: "!contains(github.event.commits[0].message, '[skip ci]')"
+    needs: fmt
+    strategy:
+      matrix:
+        backend: ["cockroachdb"]
+        tag: ["v20.2.0"]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: joschi/setup-jdk@v2 # AdoptOpenJDK
+        with:
+          java-version: 8
+      - name: Cache sbt and ivy dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+      - name: Run Integration Tests
+        env:
+          TEST_BACKEND: ${{matrix.backend}}
+          TEST_BACKEND_TAG: ${{matrix.tag}}
+        run: sbt -J-Xmx2G coverage it:test coverageReport
       - uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,12 @@ jobs:
     needs: fmt
     strategy:
       matrix:
-        postgres: [13, 12, 11, 10, 9]
+        backend: ["postgres", "cockroachdb"]
+        include:
+          - backend: "postgres"
+            tag: [13, 12, 11, 10, 9]
+          - backend: "cockroachdb"
+            tag: ["v20.2.0"]
 
     runs-on: ubuntu-latest
 
@@ -83,11 +88,12 @@ jobs:
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
       - name: Run Integration Tests
         env:
-          POSTGRES_VERSION: ${{matrix.postgres}}
+          TEST_BACKEND: ${{matrix.backend}}
+          TEST_BACKEND_TAG: ${{matrix.tag}}
         run: CI_UID_GID="$(id -u):$(id -g)" sbt -J-Xmx2G coverage it:test coverageReport
       - uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: integrationt-pg-${{matrix.postgres}}
+          flags: integration-${{matrix.backend}}-${{matrix.tag}}
           fail_ci_if_error: true
           verbose: false

--- a/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/DockerSpec.scala
+++ b/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/DockerSpec.scala
@@ -5,7 +5,10 @@ import com.whisk.docker.testkit.DockerReadyChecker
 import com.spotify.docker.client.DefaultDockerClient
 import com.spotify.docker.client.DockerClient
 import com.whisk.docker.testkit._
+import org.specs2.execute.AsResult
+import org.specs2.execute.Skipped
 import org.specs2.specification.BeforeAfterAll
+import org.specs2.main.ArgumentsShortcuts
 
 import scala.concurrent.ExecutionContext
 
@@ -33,39 +36,101 @@ trait DockerTestKitForAll extends BeforeAfterAll {
   def afterAll(): Unit = containerManager.stop()
 }
 
-trait DockerPostgresService extends DockerTestKitForAll {
+sealed trait Backend {
+  def image: String
+  def advertisedPort: Int
+  def user: String
+  def password: Option[String] = None
+  def cmd: Seq[String] = Nil
+  def env: Map[String, String]
+}
+case object Postgres extends Backend {
+  override def image: String = "postgres"
+  override def advertisedPort: Int = 5432
+  override def user: String = "postgres"
+  override def password: Option[String] = Some("test-password")
+  override def env: Map[String, String] =
+    Map(
+      "POSTGRES_USER" -> user,
+      "POSTGRES_PASSWORD" -> password.get
+    )
+}
+case object CockroachDb extends Backend {
+  override def image: String = "cockroachdb/cockroach"
+  override def advertisedPort: Int = 26257
+  override def user: String = "root"
+  override def env: Map[String, String] = Map.empty
+  override def cmd: Seq[String] = Seq("start-single-node", "--insecure")
+}
+
+trait PostgresBackendService extends DockerTestKitForAll { _: ArgumentsShortcuts =>
+
   import scala.concurrent.duration._
+  def testBackend: Backend = sys.env.get("TEST_BACKEND").map {
+    case "postgres" => Postgres
+    case "cockroachdb" => CockroachDb
+  }.getOrElse(CockroachDb)
 
-  def tag = sys.env.getOrElse("POSTGRES_VERSION", "12")
+  def tag = sys.env.getOrElse("TEST_BACKEND_TAG", "v20.2.0")
 
-  val PostgresAdvertisedPort = 5432
+  /**
+   * Only execute the spec for a specific backend
+   *
+   * {{{
+   *   class MySpec extends PostgresBackendService {
+   *     specificTo(Postgres)
+   *
+   *     "My tests" should {...}
+   *   }
+   * }}}
+   */
+  def specificTo(b: Backend) =
+    skipAllIf(testBackend != b)
 
-  val PostgresUser = "postgres"
-  val PostgresPassword = "test-password"
+  /**
+   * Used to make a single fragment backend-specific:
+   *
+   * {{{
+   *   "my fragment" in backend(Postgres) {
+   *     true
+   *   }
+   * }}}
+   *
+   * Will only execute the fragment when the backend is Postgres.
+   */
+  def backend[T: AsResult](b: Backend)(f: => T) =
+    if (b == testBackend) AsResult(f)
+    else {
+      Skipped()
+    }
 
-  val baseEnv = Map(
-    "POSTGRES_USER" -> PostgresUser,
-    "POSTGRES_PASSWORD" -> PostgresPassword
-  )
+  def env(backend: Backend): Map[String, String] = {
+    val _ = backend
+    Map.empty
+  }
 
-  def postgresContainerEnv: Map[String, String] = Map.empty
+  def configure(backend: Backend, spec: ContainerSpec): ContainerSpec = {
+    val _ = backend
+    spec
+  }
 
-  def configure(spec: ContainerSpec): ContainerSpec = spec
-
-  val postgresContainer = configure(
-    ContainerSpec(s"postgres:$tag")
-      .withExposedPorts(PostgresAdvertisedPort)
-      .withEnv((baseEnv ++ postgresContainerEnv).toList.map { case (k, v) => s"$k=$v" }: _*)
+  val container = configure(
+    testBackend,
+    ContainerSpec(s"${testBackend.image}:$tag")
+      .withExposedPorts(testBackend.advertisedPort)
+      .withEnv((testBackend.env ++ env(testBackend)).toList.map { case (k, v) => s"$k=$v" }: _*)
+      .withCommand(testBackend.cmd: _*)
       .withReadyChecker(
         DockerReadyChecker
           .Jdbc(
             driverClass = "org.postgresql.Driver",
-            user = PostgresUser,
-            password = Some(PostgresPassword)
+            user = testBackend.user,
+            password = testBackend.password
           )
           .looped(15, 1.second)
       )
   ).toContainer
 
-  override val managedContainers: ManagedContainers = postgresContainer.toManagedContainer
+  override val managedContainers: ManagedContainers = container.toManagedContainer
+
 }

--- a/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/HandshakeSpec.scala
+++ b/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/HandshakeSpec.scala
@@ -5,7 +5,9 @@ import com.whisk.docker.testkit.ContainerSpec
 
 class HandshakeSpec extends PgSqlIntegrationSpec with ResourceFileSpec {
 
-  override def configure(spec: ContainerSpec): ContainerSpec =
+  specificTo(Postgres)
+
+  override def configure(backend: Backend, spec: ContainerSpec): ContainerSpec =
     spec
       .withVolumeBindings(
         HostConfig.Bind.builder()

--- a/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/Jdbc.scala
+++ b/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/Jdbc.scala
@@ -17,7 +17,7 @@ trait Jdbc { _: PostgresConnectionSpec with PgSqlSpec =>
   def withTmpTable[T](cfg: ConnectionCfg = defaultConnectionCfg)(f: String => T) =
     withStatement(cfg) { stmt =>
       val tableName = randomTableName
-      stmt.execute(s"CREATE TABLE $tableName(int_col int)") // TODO: allow specifying the table spec
+      stmt.execute(s"CREATE TABLE $tableName(int4_col int4)") // TODO: allow specifying the table spec
       f(tableName)
     }
 }

--- a/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/PgSqlIntegrationSpec.scala
+++ b/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/PgSqlIntegrationSpec.scala
@@ -17,12 +17,13 @@ trait PostgresConnectionSpec {
 trait PgSqlIntegrationSpec
     extends PgSqlSpec
     with PostgresConnectionSpec
-    with DockerPostgresService
+    with PostgresBackendService
     with ClientEach
     with Jdbc {
+
   override def defaultConnectionCfg = ConnectionCfg(
-    username = PostgresUser,
-    password = Some(PostgresPassword),
-    port = postgresContainer.mappedPort(5432)
+    username = testBackend.user,
+    password = testBackend.password,
+    port = container.mappedPort(testBackend.advertisedPort)
   )
 }

--- a/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/PreparedStatementSpec.scala
+++ b/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/PreparedStatementSpec.scala
@@ -127,7 +127,8 @@ class PreparedStatementSpec extends PgSqlIntegrationSpec {
       case _ => Future(ko)
     }
 
-    "support portal suspension" in {
+    // TODO: investigate CRDB failure
+    "support portal suspension" in backend(Postgres) {
       val firstBatchSize = 17
       val secondBatchSize = 143
       executeSpec(InfiniteResultSetQuery, maxResults = firstBatchSize) {

--- a/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/PreparedStatementSpec.scala
+++ b/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/PreparedStatementSpec.scala
@@ -122,7 +122,7 @@ class PreparedStatementSpec extends PgSqlIntegrationSpec {
 
     // This is a hack to have a temp table to work with in the following spec.
     lazy val tableName = withTmpTable()(identity)
-    fullSpec("DML with one argument", s"INSERT INTO $tableName(int_col) VALUES($$1)", write(PgType.Int4, 56) :: Nil) {
+    fullSpec("DML with one argument", s"INSERT INTO $tableName(int4_col) VALUES($$1)", write(PgType.Int4, 56) :: Nil) {
       case Response.Command(tag) => Future(tag must beEqualTo("INSERT 0 1"))
       case _ => Future(ko)
     }

--- a/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/RichClientSpec.scala
+++ b/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/RichClientSpec.scala
@@ -30,6 +30,8 @@ class RichClientSpec extends PgSqlIntegrationSpec {
         .map(_ must beEqualTo(Response.Command("CREATE ROLE")))
     }
 
+    // TODO: COPY in CRDB cannot be done within a prepared statement
+    // https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/pgwire/conn.go#L848-L855
     "copy from" in withRichClient() { client =>
       withTmpTable() { tlbName =>
         client
@@ -38,6 +40,8 @@ class RichClientSpec extends PgSqlIntegrationSpec {
       }
     }.pendingUntilFixed()
 
+    // TODO: COPY in CRDB cannot be done within a prepared statement
+    // https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/pgwire/conn.go#L848-L855
     "copy to" in withRichClient() { client =>
       withTmpTable() { tlbName =>
         client

--- a/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/TlsSpec.scala
+++ b/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/TlsSpec.scala
@@ -13,6 +13,8 @@ import scala.jdk.CollectionConverters._
 
 class TlsSpec extends PgSqlIntegrationSpec with ResourceFileSpec {
 
+  specificTo(Postgres)
+
   /**
    * Here be dragons.
    *
@@ -52,7 +54,7 @@ class TlsSpec extends PgSqlIntegrationSpec with ResourceFileSpec {
       Set(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE).asJava
     ).toFile
 
-  override def postgresContainerEnv = Map(
+  override def env(backend: Backend) = Map(
     "PGDATA" -> "/var/lib/postgresql/data/pg_data"
   )
 
@@ -69,7 +71,7 @@ class TlsSpec extends PgSqlIntegrationSpec with ResourceFileSpec {
       .build()
   )
 
-  override def configure(spec: ContainerSpec): ContainerSpec =
+  override def configure(backend: Backend, spec: ContainerSpec): ContainerSpec =
     spec
       .withOption(runAs)((s, user) => s.withConfiguration(_.user(user)))
       .withVolumeBindings((passwdVolume.toList ++ tlsVolumes): _*)

--- a/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/types/ValueReadsEncodingSpec.scala
+++ b/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/types/ValueReadsEncodingSpec.scala
@@ -2,7 +2,9 @@ package com.twitter.finagle.postgresql.types
 
 import java.nio.charset.StandardCharsets
 
+import com.twitter.finagle.postgresql.Backend
 import com.twitter.finagle.postgresql.PgSqlIntegrationSpec
+import com.twitter.finagle.postgresql.Postgres
 import com.twitter.finagle.postgresql.PropertiesSpec
 import com.twitter.finagle.postgresql.Request
 import com.twitter.finagle.postgresql.Response
@@ -10,10 +12,12 @@ import com.twitter.util.Await
 
 class ValueReadsEncodingSpec extends PgSqlIntegrationSpec with PropertiesSpec {
 
+  specificTo(Postgres)
+
   val DbName = "iso_8859_1"
   def dbConnectionCfg = defaultConnectionCfg.copy(database = DbName)
 
-  override def postgresContainerEnv = Map(
+  override def env(backend: Backend) = Map(
     "POSTGRES_INITDB_ARGS" -> "--encoding=LATIN1 --locale=C"
   )
 

--- a/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/types/ValueReadsSpec.scala
+++ b/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/types/ValueReadsSpec.scala
@@ -7,6 +7,7 @@ import java.time.format.DateTimeFormatter
 
 import com.twitter.finagle.postgresql.PgSqlClientError
 import com.twitter.finagle.postgresql.PgSqlIntegrationSpec
+import com.twitter.finagle.postgresql.Postgres
 import com.twitter.finagle.postgresql.PropertiesSpec
 import com.twitter.finagle.postgresql.Types.Inet
 import com.twitter.finagle.postgresql.Types.WireValue
@@ -44,6 +45,8 @@ import org.specs2.matcher.describe.Diffable
  * - the `ToSqlString` trait is necessary to handle types that require finer control than `.toString`
  */
 class ValueReadsSpec extends PgSqlIntegrationSpec with PropertiesSpec {
+
+  specificTo(Postgres)
 
   // The function to convert a type to its wire representation is mostly guessable from its name, but not always.
   // This maps types to custom names, otherwise, we use the typical naming scheme.

--- a/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/types/ValueWritesSpec.scala
+++ b/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/types/ValueWritesSpec.scala
@@ -3,6 +3,7 @@ package com.twitter.finagle.postgresql.types
 import com.twitter.finagle.postgresql.Client
 import com.twitter.finagle.postgresql.Parameter
 import com.twitter.finagle.postgresql.PgSqlIntegrationSpec
+import com.twitter.finagle.postgresql.Postgres
 import com.twitter.finagle.postgresql.PropertiesSpec
 import com.twitter.finagle.postgresql.Types.Name
 import com.twitter.util.Await
@@ -33,6 +34,9 @@ import org.specs2.matcher.describe.Diffable
  * Java types.
  */
 class ValueWritesSpec extends PgSqlIntegrationSpec with PropertiesSpec {
+
+  // TODO: investigate CRDB failures
+  specificTo(Postgres)
 
   // Issues the "typed" select statement and read the value back.
   def writeAndRead[T: ValueReads](client: Client, value: T, valueWrites: ValueWrites[T], tpe: PgType) = {

--- a/finagle-postgresql/src/main/scala/com/twitter/finagle/postgresql/Response.scala
+++ b/finagle-postgresql/src/main/scala/com/twitter/finagle/postgresql/Response.scala
@@ -22,7 +22,8 @@ object Response {
   )
   case class ConnectionParameters(
     parameters: List[BackendMessage.ParameterStatus],
-    backendData: BackendMessage.BackendKeyData
+    // Not implemented in CRDB: https://github.com/cockroachdb/cockroach/pull/13009
+    backendData: Option[BackendMessage.BackendKeyData],
   ) extends Response {
 
     lazy val parameterMap: Map[BackendMessage.Parameter, String] =
@@ -43,7 +44,7 @@ object Response {
     }
   }
   object ConnectionParameters {
-    val empty: ConnectionParameters = ConnectionParameters(Nil, BackendMessage.BackendKeyData(pid = -1, secret = -1))
+    val empty: ConnectionParameters = ConnectionParameters(Nil, None)
   }
 
   sealed trait QueryResponse extends Response


### PR DESCRIPTION
Refactors the integration tests to be able to test against CockroachDB.

Not all specs can be executed since CRDB doesn't implement the whole protocol and some utility functions (i.e.: `int4send` and such).

Some tooling is provided to be able to skip whole specs or individual fragments when necessary.