### PR TITLE
fix: use int2 data type for reading/writing Byte.

### DIFF
--- a/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/types/ValueReadsSpec.scala
+++ b/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/types/ValueReadsSpec.scala
@@ -135,7 +135,7 @@ class ValueReadsSpec extends PgSqlIntegrationSpec with PropertiesSpec {
     "readsBigDecimal" should failFor(ValueReads.readsBigDecimal, "NaN", PgType.Numeric)
     "readsBool" should simpleSpec(ValueReads.readsBoolean, PgType.Bool)
     "readsBuf" should simpleSpec(ValueReads.readsBuf, PgType.Bytea)
-    "readsByte" should simpleSpec(ValueReads.readsByte, PgType.Char)
+    "readsByte" should simpleSpec(ValueReads.readsByte, PgType.Int2)
     "readsDouble" should simpleSpec(ValueReads.readsDouble, PgType.Float8)
     "readsFloat" should simpleSpec(ValueReads.readsFloat, PgType.Float4)
     "readsInet" should simpleSpec(ValueReads.readsInet, PgType.Inet)

--- a/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/types/ValueWritesSpec.scala
+++ b/finagle-postgresql/src/it/scala/com/twitter/finagle/postgresql/types/ValueWritesSpec.scala
@@ -79,7 +79,7 @@ class ValueWritesSpec extends PgSqlIntegrationSpec with PropertiesSpec {
     "writesBigDecimal" should simpleSpec(ValueWrites.writesBigDecimal, PgType.Numeric)
     "writesBool" should simpleSpec(ValueWrites.writesBoolean, PgType.Bool)
     "writesBuf" should simpleSpec(ValueWrites.writesBuf, PgType.Bytea)
-    "writesByte" should simpleSpec(ValueWrites.writesByte, PgType.Char)
+    "writesByte" should simpleSpec(ValueWrites.writesByte, PgType.Int2)
     "writesDouble" should simpleSpec(ValueWrites.writesDouble, PgType.Float8)
     "writesFloat" should simpleSpec(ValueWrites.writesFloat, PgType.Float4)
     "writesInet" should simpleSpec(ValueWrites.writesInet, PgType.Inet)

--- a/finagle-postgresql/src/test/scala/com/twitter/finagle/postgresql/types/ValueWritesSpec.scala
+++ b/finagle-postgresql/src/test/scala/com/twitter/finagle/postgresql/types/ValueWritesSpec.scala
@@ -175,7 +175,11 @@ class ValueWritesSpec extends PgSqlSpec with PropertiesSpec {
         bb.put(Buf.ByteArray.Shared.extract(buf))
       }
     }
-    "writesByte" should simpleSpec[Byte](ValueWrites.writesByte, PgType.Char)(byte => Buf.ByteArray(byte))
+    "writesByte" should simpleSpec[Byte](ValueWrites.writesByte, PgType.Int2) { byte =>
+      mkBuf() { bb =>
+        bb.putShort(byte.toShort)
+      }
+    }
     "writesDouble" should simpleSpec[Double](ValueWrites.writesDouble, PgType.Float8) { double =>
       mkBuf() { bb =>
         bb.putDouble(double)


### PR DESCRIPTION
Postgres doesn't have a numerical 1-byte data type. Mapping to its "char" type works, but is hard to use in practice since libraries have to do type casts (e.g.: 56::"char") and the "char" type is considered "internal".